### PR TITLE
Disable text highlighting in tabs

### DIFF
--- a/templates:tabs.css
+++ b/templates:tabs.css
@@ -12,6 +12,12 @@
   margin: 0;
   list-style: none;
   cursor: pointer;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 .basicTabs-container .tabs-list .tab-item.active,
 .dynamicTabs-container .tabs-list .tab-item.active {


### PR DESCRIPTION
Disable text selection in tabs, like this, from happening:

<img width="590" alt="screen shot 2016-01-04 at 12 02 02 pm" src="https://cloud.githubusercontent.com/assets/1842727/12081859/1c268fcc-b2db-11e5-9f9b-841caf5ad627.png">
