### PR TITLE
Fix a problem which is all sections displayed at the same time before onRendered happen

### DIFF
--- a/templates_tabs.html
+++ b/templates_tabs.html
@@ -55,7 +55,7 @@
 
 
 <template name="tabContent">
-  <section class="tabs-content {{isActiveTab slug}}" data-tab={{slug}}>
+  <section style="display:none" class="tabs-content {{isActiveTab slug}}" data-tab={{slug}}>
     {{> UI.contentBlock}}
   </section>
 </template>


### PR DESCRIPTION
When the user use the forward/backward to page will appear this problem
