### PR TITLE
Explicitly export the ReactiveTabs symbol

### DIFF
--- a/package.js
+++ b/package.js
@@ -16,6 +16,7 @@ Package.onUse(function(api) {
   api.addFiles('templates_tabs.html', 'client');
   api.addFiles('templates_tabs.coffee', 'client');
   api.addFiles('templates_tabs.css', 'client');
+  api.export('ReactiveTabs', 'client');
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
This is required if we want to use ES6 imports in Meteor 1.3.